### PR TITLE
Avoid usage of for..in to be optimizable.

### DIFF
--- a/lib/qlobber.js
+++ b/lib/qlobber.js
@@ -204,9 +204,29 @@ Qlobber.prototype._remove = function (val, i, words, sub_trie)
     delete sub_trie[word];
 };
 
+function forInRep(self, v, i, words, st) {
+
+  var keys = Object.keys(st), j = 0, w = null;
+
+  for (j = 0; j < keys.length; j += 1)
+  {
+    w = keys[j];
+    if (w !== self._separator)
+    {
+        for (j = i; j < words.length; j += 1)
+        {
+          v = self._match(v, j, words, st);
+        }
+        break;
+    }
+  }
+
+  return v;
+}
+
 Qlobber.prototype._match = function (v, i, words, sub_trie)
 {
-    var word, st, w, j;
+    var word, st;
 
     st = sub_trie[this._wildcard_some];
 
@@ -214,20 +234,7 @@ Qlobber.prototype._match = function (v, i, words, sub_trie)
     {
         // common case: no more levels
 
-        /*jslint forin: true */
-        for (w in st)
-        {
-            if (w !== this._separator)
-            {
-                for (j = i; j < words.length; j += 1)
-                {
-                    v = this._match(v, j, words, st);
-                }
-
-                break;
-            }
-        }
-        /*jslint forin: false */
+        v = forInRep(this, v, i, words, st);
 
         v = this._match(v, words.length, words, st);
     }


### PR DESCRIPTION
Before this patch:

```
[marking Qlobber._match 0x2387f8d59ba8 for recompilation, reason: hot and stable, ICs with typeinfo: 16/27 (59%)]
[disabled optimization for Qlobber._match, reason: ForInStatement is not fast case]
```

after

```
[optimizing: Qlobber._match / 27f4b2159c59 - took 0.149, 0.378, 0.000 ms]
```
