### PR TITLE
Do not use concat or push, as they are slower

### DIFF
--- a/lib/qlobber.js
+++ b/lib/qlobber.js
@@ -130,7 +130,7 @@ Qlobber.prototype._add = function (val, i, words, sub_trie)
         
         if (st)
         {
-            st.push(val);
+            st[st.length] = val;
         }
         else
         {
@@ -224,6 +224,16 @@ function forInRep(self, v, i, words, st) {
   return v;
 }
 
+function addAll(dest, origin) {
+  var i, destLength = dest.length, originLength = origin.length;
+
+  for (i = 0; i < originLength; i += 1) {
+    dest[destLength + i] = origin[i];
+  }
+
+  return dest;
+}
+
 Qlobber.prototype._match = function (v, i, words, sub_trie)
 {
     var word, st;
@@ -245,7 +255,7 @@ Qlobber.prototype._match = function (v, i, words, sub_trie)
 
         if (st)
         {
-            v = v.concat(st);
+            v = addAll(v, st);
         }
     }
     else


### PR DESCRIPTION
Before:

```
Running "exec:bench" (exec) task

  add_match_remove x10,000
  ┌─────────┬────────────┬──────────────┬──────────┐
  │         │ total (ms) │ average (ns) │ diff (%) │
  ├─────────┼────────────┼──────────────┼──────────┤
  │ default │      2,121 │      212,112 │        - │
  └─────────┴────────────┴──────────────┴──────────┘

  match x10,000
  ┌─────────┬────────────┬──────────────┬──────────┐
  │         │ total (ms) │ average (ns) │ diff (%) │
  ├─────────┼────────────┼──────────────┼──────────┤
  │ default │      1,794 │      179,360 │        - │
  └─────────┴────────────┴──────────────┴──────────┘
```

After:

```
Running "exec:bench" (exec) task

  add_match_remove x10,000
  ┌─────────┬────────────┬──────────────┬──────────┐
  │         │ total (ms) │ average (ns) │ diff (%) │
  ├─────────┼────────────┼──────────────┼──────────┤
  │ default │      1,863 │      186,305 │        - │
  └─────────┴────────────┴──────────────┴──────────┘

  match x10,000
  ┌─────────┬────────────┬──────────────┬──────────┐
  │         │ total (ms) │ average (ns) │ diff (%) │
  ├─────────┼────────────┼──────────────┼──────────┤
  │ default │      1,599 │      159,912 │        - │
  └─────────┴────────────┴──────────────┴──────────┘
```