### PR TITLE
Add rh, rap, nl to Aedes

### DIFF
--- a/aedes/qlobber-sub.js
+++ b/aedes/qlobber-sub.js
@@ -19,23 +19,23 @@ QlobberSub.prototype._initial_value = function (val)
 
     let r = {
         topic: val.topic,
-        clientMap: new Map().set(val.clientId, val.qos),
+        clientMap: new Map().set(val.clientId, { qos: val.qos, rh: val.rh, rap: val.rap, nl: val.nl }),
     };
 
     r[Symbol.iterator] = function* (topic)
     {
         if (topic === undefined)
         {
-            for (let [clientId, qos] of r.clientMap)
+            for (let [clientId, sub] of r.clientMap)
             {
-                yield { topic: r.topic, clientId, qos };
+                yield { topic: r.topic, clientId, ...sub };
             }
         }
         else if (r.topic === topic)
         {
-            for (let [clientId, qos] of r.clientMap)
+            for (let [clientId, sub] of r.clientMap)
             {
-                yield { clientId, qos };
+                yield { clientId, ...sub };
             }
         }
     };
@@ -48,7 +48,7 @@ QlobberSub.prototype._add_value = function (existing, val)
     var clientMap = existing.clientMap,
         size = clientMap.size;
 
-    clientMap.set(val.clientId, val.qos);
+    clientMap.set(val.clientId, { qos: val.qos, rh: val.rh, rap: val.rap, nl: val.nl });
 
     if (clientMap.size > size)
     {
@@ -58,28 +58,18 @@ QlobberSub.prototype._add_value = function (existing, val)
 
 QlobberSub.prototype._add_values = function (dest, existing, topic)
 {
-    var clientIdAndQos;
     if (topic === undefined)
     {
-        for (clientIdAndQos of existing.clientMap)
+        for (let [clientId, sub] of existing.clientMap)
         {
-            dest.push(
-            {
-                clientId: clientIdAndQos[0],
-                topic: existing.topic,
-                qos: clientIdAndQos[1]
-            });
+            dest.push({ clientId, topic: existing.topic, ...sub });
         }
     }
     else if (existing.topic === topic)
     {
-        for (clientIdAndQos of existing.clientMap)
+        for (let [clientId, sub] of existing.clientMap)
         {
-            dest.push(
-            {
-                clientId: clientIdAndQos[0],
-                qos: clientIdAndQos[1]
-            });
+            dest.push({ clientId,...sub });
         }
     }
 };

--- a/test/aedes.js
+++ b/test/aedes.js
@@ -18,14 +18,20 @@ function test(type, QlobberSub)
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(1);
         expect(matcher.match('foo.bar')).to.eql([
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         }]);
         expect(matcher.test('foo.bar',
         {
@@ -47,21 +53,30 @@ function test(type, QlobberSub)
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(1);
         matcher.add('foo.bar',
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(1);
         expect(matcher.match('foo.bar')).to.eql([
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         }]);
         expect(matcher.test('foo.bar',
         {
@@ -83,26 +98,38 @@ function test(type, QlobberSub)
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(1);
         matcher.add('foo.bar',
         {
             clientId: 'test2',
             topic: 'foo.bar',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(2);
         expect(common.ordered_sort(matcher.match('foo.bar'))).to.eql([
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         },
         {
             clientId: 'test2',
             topic: 'foo.bar',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         }]);
         expect(matcher.test('foo.bar',
         {
@@ -124,26 +151,38 @@ function test(type, QlobberSub)
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(1);
         matcher.add('foo.*',
         {
             clientId: 'test1',
             topic: 'foo.*',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(2);
         expect(matcher.match('foo.bar')).to.eql([
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         },
         {
             clientId: 'test1',
             topic: 'foo.*',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         }]);
         expect(matcher.test('foo.bar',
         {
@@ -175,14 +214,20 @@ function test(type, QlobberSub)
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(1);
         matcher.add('foo.bar',
         {
             clientId: 'test2',
             topic: 'foo.bar',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(2);
         matcher.remove('foo.bar',
@@ -195,7 +240,10 @@ function test(type, QlobberSub)
         {
             clientId: 'test2',
             topic: 'foo.bar',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         }]);
         expect(matcher.test('foo.bar',
         {
@@ -217,52 +265,79 @@ function test(type, QlobberSub)
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(1);
         matcher.add('foo.*',
         {
             clientId: 'test1',
             topic: 'foo.*',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(2);
         matcher.add('foo.bar',
         {
             clientId: 'test2',
             topic: 'foo.bar',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(3);
         expect(common.ordered_sort(matcher.match('foo.bar'))).to.eql([
         {
             clientId: 'test1',
             topic: 'foo.*',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         },
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         },
         {
             clientId: 'test2',
             topic: 'foo.bar',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         }]);
         expect(common.ordered_sort(matcher.match('foo.bar', 'foo.bar'))).to.eql([
         {
             clientId: 'test1',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         },
         {
             clientId: 'test2',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         }]);
         expect(matcher.match('foo.bar', 'foo.*')).to.eql([
         {
             clientId: 'test1',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         }]);
     });
 
@@ -274,14 +349,20 @@ function test(type, QlobberSub)
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(1);
         matcher.add('foo.bar',
         {
             clientId: 'test2',
             topic: 'foo.bar',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(2);
         matcher.remove('foo.bar',
@@ -300,7 +381,10 @@ function test(type, QlobberSub)
         {
             clientId: 'test2',
             topic: 'foo.bar',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         }]);
         expect(matcher.test('foo.bar',
         {
@@ -334,14 +418,20 @@ function test(type, QlobberSub)
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(1);
         expect(matcher.match('foo.bar')).to.eql([
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         }]);
         expect(matcher.test('foo.bar',
         {
@@ -376,21 +466,30 @@ function test(type, QlobberSub)
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(1);
         matcher.add('foo.*',
         {
             clientId: 'test2',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(2);
         matcher.add('foo.*',
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(3);
         matcher.remove('foo.*',
@@ -411,11 +510,11 @@ function test(type, QlobberSub)
         { type: 'start_values' },
         {
           type: 'value',
-          value: { topic: 'foo.bar', clientId: 'test1', qos: 1 }
+          value: { topic: 'foo.bar', clientId: 'test1', qos: 1, rh: 0, rap: true, nl: false }
         },
         {
           type: 'value',
-          value: { topic: 'foo.bar', clientId: 'test2', qos: 2 }
+          value: { topic: 'foo.bar', clientId: 'test2', qos: 2, rh: 0, rap: true, nl: false }
         },
         { type: 'end_values' },
         { type: 'end_entries' },
@@ -425,11 +524,11 @@ function test(type, QlobberSub)
         { type: 'start_values' },
         {
           type: 'value',
-          value: { topic: 'foo.bar2', clientId: 'test1', qos: 1 }
+          value: { topic: 'foo.bar2', clientId: 'test1', qos: 1, rh: 0, rap: true, nl: false }
         },
         {
           type: 'value',
-          value: { topic: 'foo.bar2', clientId: 'test2', qos: 2 }
+          value: { topic: 'foo.bar2', clientId: 'test2', qos: 2, rh: 0, rap: true, nl: false }
         },
         { type: 'end_values' },
         { type: 'end_entries' },
@@ -445,28 +544,40 @@ function test(type, QlobberSub)
         {
             clientId: 'test1',
             topic: 'foo.bar',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(1);
         matcher.add('foo.bar',
         {
             clientId: 'test2',
             topic: 'foo.bar',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(2);
         matcher.add('foo.bar2',
         {
             clientId: 'test1',
             topic: 'foo.bar2',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(3);
         matcher.add('foo.bar2',
         {
             clientId: 'test2',
             topic: 'foo.bar2',
-            qos: 2
+            qos: 2,
+            rh: 0,
+            rap: true,
+            nl: false
         });
         expect(matcher.subscriptionsCount).to.equal(4);
 
@@ -497,18 +608,18 @@ function test(type, QlobberSub)
             restorer(v);
         }
 
-        expect(common.get_trie(matcher)).to.eql({"foo":{"bar2":{".":[{"topic":"foo.bar2","clientId":"test1","qos":1},{"topic":"foo.bar2","clientId":"test2","qos":2}]},"bar":{".":[{"topic":"foo.bar","clientId":"test1","qos":1},{"topic":"foo.bar","clientId":"test2","qos":2}]}}});
+        expect(common.get_trie(matcher)).to.eql({"foo":{"bar2":{".":[{"topic":"foo.bar2","clientId":"test1","qos":1, rh: 0, rap: true, nl: false},{"topic":"foo.bar2","clientId":"test2","qos":2, rh: 0, rap: true, nl: false}]},"bar":{".":[{"topic":"foo.bar","clientId":"test1","qos":1, rh: 0, rap: true, nl: false},{"topic":"foo.bar","clientId":"test2","qos":2, rh: 0, rap: true, nl: false}]}}});
     });
 
     it('should support match iterator', function ()
     {
         var matcher = new QlobberSub();
-        matcher.add('foo.bar', { clientId: 'test1', topic: 'foo.bar', qos: 1 });
-        matcher.add('foo.*', { clientId: 'test1', topic: 'foo.*', qos: 2 });
+        matcher.add('foo.bar', { clientId: 'test1', topic: 'foo.bar', qos: 1, rh: 0, rap: true, nl: false });
+        matcher.add('foo.*', { clientId: 'test1', topic: 'foo.*', qos: 2, rh: 0, rap: true, nl: false });
 
         let expected_matches = [
-            { topic: 'foo.bar', clientId: 'test1', qos: 1 },
-            { topic: 'foo.*', clientId: 'test1', qos: 2 }
+            { topic: 'foo.bar', clientId: 'test1', qos: 1, rh: 0, rap: true, nl: false },
+            { topic: 'foo.*', clientId: 'test1', qos: 2, rh: 0, rap: true, nl: false }
         ];
 
         let objs = [];
@@ -530,7 +641,7 @@ function test(type, QlobberSub)
         {
             objs.push(v);
         }
-        expect(objs).to.eql([ { clientId: 'test1', qos: 1 } ]);
+        expect(objs).to.eql([ { clientId: 'test1', qos: 1, rh: 0, rap: true, nl: false } ]);
     });
 });
 


### PR DESCRIPTION
Hi,

I am working on fixing Aedes bridge connection where `nl` flag is not respected:

https://github.com/moscajs/aedes/issues/736

For that I need to update qlobber to work with `nl`, `rap` and `rh` flags.

I have made the changes as seen in this pull request.

When I run `npm run test` the native Aedes tests fail:

![image](https://user-images.githubusercontent.com/37391/167072805-f1742130-d3b1-4aa8-84b1-da4d7353763f.png)

Any idea how to make them not to fail?

PS: I am using gitpoid.io to make changes and run tests as I have no Linux machine at hand.